### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ SwiftPagingNav
 
 A Twitter-like navigation bar and page viewer written in Swift.
 
-##Example
+## Example
  
 ![alt tag](http://i.imgur.com/GrrE52v.gif)
 
-##Requirements
+## Requirements
 * iOS 7.0+
 * ARC
 
-##Installation
+## Installation
 Download PageViewController.swift and customize it as needed.
 You can also subclass the UIViews that load into the ScrollView.
 This code has been laid out for ease of understanding vs highly optimized production code.
 
-##License 
+## License 
 MIT License
 
-##Authors
+## Authors
 Aubrey Johnson - http://twitter.com/aub
 
 Chad Timmerman - http://twitter.com/chadtimmerman


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
